### PR TITLE
Lock to @wordpress/eslint-plugin 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -165,17 +165,15 @@
       }
     },
     "@wordpress/eslint-plugin": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-3.4.0.tgz",
-      "integrity": "sha512-m5QFs84M3YUyikw1gaGpd4pe6X8sCcBnnILZDuJIkCmpWcdoE31WoEcd6xJTlZjAcqi8Gg9NO7vnBSXxlURpOw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-3.3.0.tgz",
+      "integrity": "sha512-wS7eoHlOrsEN8HXRQw2WV2IpYRHv3rqCkfb/o9huuz66Tq2hi8xZDQGiDn7BSxQb5DYwOs2TJImCXwv3eKsPSg==",
       "dev": true,
       "requires": {
-        "babel-eslint": "^10.0.3",
-        "eslint-config-prettier": "^6.10.0",
+        "babel-eslint": "^10.0.2",
         "eslint-plugin-jest": "^22.15.1",
         "eslint-plugin-jsdoc": "^15.8.0",
         "eslint-plugin-jsx-a11y": "^6.2.3",
-        "eslint-plugin-prettier": "^3.1.2",
         "eslint-plugin-react": "^7.14.3",
         "eslint-plugin-react-hooks": "^1.6.1",
         "globals": "^12.0.0",
@@ -555,15 +553,6 @@
         }
       }
     },
-    "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
-      "dev": true,
-      "requires": {
-        "get-stdin": "^6.0.0"
-      }
-    },
     "eslint-plugin-jest": {
       "version": "22.21.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.21.0.tgz",
@@ -602,15 +591,6 @@
         "emoji-regex": "^7.0.2",
         "has": "^1.0.3",
         "jsx-ast-utils": "^2.2.1"
-      }
-    },
-    "eslint-plugin-prettier": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
-      "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
-      "dev": true,
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-react": {
@@ -726,12 +706,6 @@
       "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
       "dev": true
     },
-    "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
-      "dev": true
-    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -795,12 +769,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
-    },
-    "get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "glob": {
@@ -1281,15 +1249,6 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
-    },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "^1.1.2"
-      }
     },
     "progress": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint ./src --debug"
   },
   "devDependencies": {
-    "@wordpress/eslint-plugin": "^3.4.0",
+    "@wordpress/eslint-plugin": "3.3.0",
     "eslint": "^6.8.0"
   }
 }


### PR DESCRIPTION
Reverting to 3.3.0 fixes the problem.